### PR TITLE
[Fix] DrawSelectResultFragment.getBinding NullPointer 에러 해결

### DIFF
--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/data/remote/KustaurantApi.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/data/remote/KustaurantApi.kt
@@ -26,7 +26,6 @@ interface KustaurantApi {
     @GET("/api/v1/draw")
     suspend fun getDrawRestaurantsData(
         @Query("cuisines") cuisines: String,
-        @Query("situations") situations: String,
         @Query("locations") locations: String
     ):  List<DrawRestaurantData>
 }

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/data/repository/DrawRepositoryImpl.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/data/repository/DrawRepositoryImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class DrawRepositoryImpl @Inject constructor(
     private val kustaurantApi: KustaurantApi
 ) : DrawRepository {
-    override suspend fun getDrawRestaurantData(cuisines: String, situations: String, locations: String): List<DrawRestaurantData> {
-        return kustaurantApi.getDrawRestaurantsData(cuisines, situations, locations)
+    override suspend fun getDrawRestaurantData(cuisines: String, locations: String): List<DrawRestaurantData> {
+        return kustaurantApi.getDrawRestaurantsData(cuisines, locations)
     }
 }

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/domain/repository/DrawRepository.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/domain/repository/DrawRepository.kt
@@ -4,5 +4,5 @@ import com.kust.kustaurant.data.model.DrawRestaurantData
 
 
 interface DrawRepository {
-    suspend fun getDrawRestaurantData(cuisines: String, situations : String, locations: String):  List<DrawRestaurantData>
+    suspend fun getDrawRestaurantData(cuisines: String, locations: String):  List<DrawRestaurantData>
 }

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/domain/usecase/draw/GetDrawRestaurantUseCase.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/domain/usecase/draw/GetDrawRestaurantUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 
 class GetDrawRestaurantUseCase @Inject constructor(
     private val drawRepository: DrawRepository) {
-    suspend operator fun invoke(cuisines: String, situations: String, locations: String):  List<DrawRestaurantData> {
-        return drawRepository.getDrawRestaurantData(cuisines, situations, locations)
+    suspend operator fun invoke(cuisines: String, locations: String):  List<DrawRestaurantData> {
+        return drawRepository.getDrawRestaurantData(cuisines, locations)
     }
 }

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawSelectCategoryFragment.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawSelectCategoryFragment.kt
@@ -58,10 +58,10 @@ class DrawSelectCategoryFragment : Fragment() {
         observeViewModel()
 
         binding.drawBtnDrawRandomRestaurants.setOnClickListener {
-            val selectedSituation = getSelectedTogglesText(binding.tierToggleSituationGroup)
+            //val selectedSituation = getSelectedTogglesText(binding.tierToggleSituationGroup)
             val selectedLocation = getSelectedTogglesText(binding.tierToggleLocationGroup)
 
-            viewModel.applyFilters(selectedMenus, selectedSituation, selectedLocation)
+            viewModel.applyFilters(selectedMenus,selectedLocation)
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.draw_fragment_container, DrawSelectResultFragment())
@@ -72,7 +72,7 @@ class DrawSelectCategoryFragment : Fragment() {
 
     private fun setupToggleGroups() {
         setupToggleGroup(binding.tierToggleLocationGroup)
-        setupToggleGroup(binding.tierToggleSituationGroup)
+        //setupToggleGroup(binding.tierToggleSituationGroup)
         initMenuClickListeners()
     }
 
@@ -82,9 +82,6 @@ class DrawSelectCategoryFragment : Fragment() {
         }
         viewModel.selectedLocations.observe(viewLifecycleOwner) { selectedTypes ->
             updateToggleGroupSelection(binding.tierToggleLocationGroup, selectedTypes)
-        }
-        viewModel.selectedSituations.observe(viewLifecycleOwner) { selectedTypes ->
-            updateToggleGroupSelection(binding.tierToggleSituationGroup, selectedTypes)
         }
     }
 

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawSelectResultFragment.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawSelectResultFragment.kt
@@ -25,6 +25,8 @@ class DrawSelectResultFragment : Fragment() {
     private lateinit var adapter: DrawSelectResultAdapter
     private var restaurantList = mutableListOf<DrawRestaurantData>()
     private val viewModel: DrawViewModel by activityViewModels()
+    private var handler: Handler? = null
+    private var runnable: Runnable? = null
     val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -45,9 +47,26 @@ class DrawSelectResultFragment : Fragment() {
         }
 
         viewModel.selectedRestaurant.observe(viewLifecycleOwner) { selected ->
+            if (_binding == null) {
+                _binding = FragmentDrawSelectResultBinding.inflate(layoutInflater)
+            }
+
             displaySelectedRestaurantInfo(selected)
         }
     }
+
+
+    @SuppressLint("SetTextI18n")
+    private fun displaySelectedRestaurantInfo(restaurant: DrawRestaurantData) {
+        binding.drawTvRestaurantName.text = restaurant.restaurantName
+        binding.drawTvRestaurantMenu.text = restaurant.restaurantMenu
+        binding.drawTvRestaurantScore.text = restaurant.restaurantScoreSum.toString()
+        binding.drawTvRestaurantPartnershipInfo.text = "이과대학 학생증 제시 시 99퍼센트 할인적용"
+
+        updateStarRating(restaurant.restaurantScoreSum)
+    }
+
+
 
     private fun setupViewPager() {
         viewPager = binding.drawViewPager
@@ -64,16 +83,6 @@ class DrawSelectResultFragment : Fragment() {
             }
         }
         viewPager.setPageTransformer(pageTransformer)
-    }
-
-    @SuppressLint("SetTextI18n")
-    private fun displaySelectedRestaurantInfo(restaurant: DrawRestaurantData) {
-        binding.drawTvRestaurantName.text = restaurant.restaurantName
-        binding.drawTvRestaurantMenu.text = restaurant.restaurantMenu
-        binding.drawTvRestaurantScore.text = restaurant.restaurantScoreSum.toString()
-        binding.drawTvRestaurantPartnershipInfo.text = "이과대학 학생증 제시 시 99퍼센트 할인적용"
-
-        updateStarRating(restaurant.restaurantScoreSum)
     }
 
     private fun updateStarRating(score: Double) {
@@ -129,18 +138,23 @@ class DrawSelectResultFragment : Fragment() {
         val centerPosition = viewPager.currentItem
         adapter.highlightItem(centerPosition)
     }
-
     private fun startAnimation() {
         disableButtons() // 애니메이션 시작 시 버튼 비활성화
 
-        val handler = Handler(Looper.getMainLooper())
-        val runnable = object : Runnable {
+        handler = Handler(Looper.getMainLooper())
+        runnable = object : Runnable {
             var currentPage = 0
             override fun run() {
+                // Fragment가 아직 활성 상태인지 확인
+                if (!isAdded || view == null || _binding == null) {
+                    handler?.removeCallbacks(this) // 핸들러에서 콜백 제거
+                    return
+                }
+
                 if (currentPage < adapter.itemCount) {
                     viewPager.setCurrentItem(currentPage++, true)
-                    handler.postDelayed(this, 2000L / adapter.itemCount)
-                    displaySelectedRestaurantInfo(restaurantList[currentPage-1])
+                    handler?.postDelayed(this, 2000L / adapter.itemCount)
+                    displaySelectedRestaurantInfo(restaurantList[currentPage - 1])
                 } else {
                     // 애니메이션 종료 후, 중앙에 선택된 음식점 배치
                     viewModel.selectedRestaurant.value?.let { selected ->
@@ -153,7 +167,7 @@ class DrawSelectResultFragment : Fragment() {
                 }
             }
         }
-        handler.post(runnable)
+        handler?.post(runnable!!)
     }
 
 
@@ -174,6 +188,10 @@ class DrawSelectResultFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+
+        handler?.removeCallbacks(runnable!!)
+        handler = null
+        runnable = null
         _binding = null
     }
 }

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawViewModel.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/draw/DrawViewModel.kt
@@ -24,14 +24,10 @@ class DrawViewModel @Inject constructor(
     private val _selectedMenus = MutableLiveData<Set<String>>(setOf("전체"))
     val selectedMenus: LiveData<Set<String>> = _selectedMenus
 
-    private val _selectedSituations = MutableLiveData<Set<String>>(setOf("전체"))
-    val selectedSituations: LiveData<Set<String>> = _selectedSituations
-
     private val _selectedLocations = MutableLiveData<Set<String>>(setOf("전체"))
     val selectedLocations: LiveData<Set<String>> = _selectedLocations
 
     private var _initialSelectedMenus = setOf("전체")
-    private var _initialSelectedSituations = setOf("전체")
     private var _initialSelectedLocations = setOf("전체")
 
     private val _selectedRestaurant = MutableLiveData<DrawRestaurantData>()
@@ -40,7 +36,6 @@ class DrawViewModel @Inject constructor(
     fun drawRestaurants() {
         viewModelScope.launch {
             val checkSameCategory = (selectedMenus.value == _initialSelectedMenus) &&
-                    (selectedSituations.value == _initialSelectedSituations) &&
                     (selectedLocations.value == _initialSelectedLocations)
 
             if (checkSameCategory && sameDrawList < 2) {
@@ -59,11 +54,9 @@ class DrawViewModel @Inject constructor(
 
                 val mappedMenus = selectedMenus.value?.let { CategoryIdMapper.mapMenus(it) }
                 val mappedLocations = selectedLocations.value?.let { CategoryIdMapper.mapLocations(it) }
-                val mappedSituations = selectedSituations.value?.let { CategoryIdMapper.mapSituations(it) }
 
                 val drawRestaurantsListData = getDrawRestaurantUseCase(
                     Uri.encode(mappedMenus),
-                    Uri.encode(mappedSituations),
                     Uri.encode(mappedLocations)
                 )
                 _drawList.value = drawRestaurantsListData
@@ -93,22 +86,16 @@ class DrawViewModel @Inject constructor(
         _selectedMenus.value = types
     }
 
-    private fun setSelectedSituations(situations: Set<String>) {
-        _selectedSituations.value = situations
-    }
-
     private fun setSelectedLocations(locations: Set<String>) {
         _selectedLocations.value = locations
     }
 
-    fun applyFilters(types: Set<String>, situations: Set<String>, locations: Set<String>) {
+    fun applyFilters(types: Set<String>, locations: Set<String>) {
         setSelectedTypes(types)
-        setSelectedSituations(situations)
         setSelectedLocations(locations)
 
         // 현재 선택된 값들을 새로운 "초기" 값으로 설정
         _initialSelectedMenus = types
-        _initialSelectedSituations = situations
         _initialSelectedLocations = locations
 
         sameDrawList = 3

--- a/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/tier/TierListFragment.kt
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/java/com/kust/kustaurant/presentation/ui/tier/TierListFragment.kt
@@ -30,9 +30,7 @@ class TierListFragment : Fragment() {
         setupRecyclerView()
 
         binding.tierSrl.setOnRefreshListener {
-            viewModel.checkAndLoadBackendData(0)
-            binding.tierRecyclerView.scrollToPosition(0)
-            binding.tierSrl.isRefreshing = false
+            refreshData()
         }
 
         return binding.root
@@ -70,6 +68,12 @@ class TierListFragment : Fragment() {
             tierAdapter.setExpanded(isExpanded)
         }
 
+    }
+
+    private fun refreshData() {
+        viewModel.checkAndLoadBackendData(0)
+        binding.tierRecyclerView.scrollToPosition(0)
+        binding.tierSrl.isRefreshing = false
     }
 
     override fun onResume() {

--- a/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_draw.xml
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_draw.xml
@@ -10,14 +10,32 @@
             type="com.kust.kustaurant.presentation.ui.tier.TierViewModel" />
     </data>
 
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.ui.draw.DrawFragment">
 
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
+
+            <!--  GuideLine 생성-->
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/draw_gl_start"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.05" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/draw_gl_end"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.95"/>
+
 
             <!-- Top Bar -->
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -26,8 +44,8 @@
                 android:layout_height="0dp"
                 android:paddingTop="5dp"
                 app:layout_constraintDimensionRatio="360:60"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/draw_gl_end"
+                app:layout_constraintStart_toStartOf="@id/draw_gl_start"
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TextView

--- a/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_draw_select_category.xml
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_draw_select_category.xml
@@ -142,187 +142,6 @@
             </LinearLayout>
         </HorizontalScrollView>
 
-        <HorizontalScrollView
-            android:id="@+id/draw_sv_select_situation"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="26dp"
-            android:scrollbars="none"
-            app:layout_constraintDimensionRatio="360:35"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/draw_sv_select_type"
-            tools:layout_height="35dp">
-
-            <LinearLayout
-                android:id="@+id/tier_toggle_situation_group"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:gravity="center_vertical">
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_ALL"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="전체"
-                    android:textOn="전체" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_ONE"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="혼밥"
-                    android:textOn="혼밥" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_TWO"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="2~4인"
-                    android:textOn="2~4인" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_THREE"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="5인 이상"
-                    android:textOn="5인 이상" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_FOUR"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="단체 회식"
-                    android:textOn="단체 회식" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_FIVE"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="배달"
-                    android:textOn="배달" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_SIX"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="야식"
-                    android:textOn="야식" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_SEVEN"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="친구 초대"
-                    android:textOn="친구 초대" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_EIGHT"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="5dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="데이트"
-                    android:textOn="데이트" />
-
-                <ToggleButton
-                    android:id="@+id/tier_toggle_situation_NINE"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginBottom="7dp"
-                    android:background="@drawable/btn_toggle_background"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    android:paddingLeft="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingRight="16dp"
-                    android:paddingBottom="4dp"
-                    android:textColor="@color/cement_4"
-                    android:textOff="소개팅"
-                    android:textOn="소개팅" />
-
-            </LinearLayout>
-        </HorizontalScrollView>
 
         <!-- Start Guideline -->
         <androidx.constraintlayout.widget.Guideline
@@ -343,13 +162,12 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/draw_cl_menu_group"
             android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="8dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="26dp"
             app:layout_constraintDimensionRatio="360:375"
             app:layout_constraintEnd_toEndOf="@id/draw_gl_end"
-            app:layout_constraintHorizontal_bias="0.51"
             app:layout_constraintStart_toStartOf="@id/draw_gl_start"
-            app:layout_constraintTop_toBottomOf="@id/draw_sv_select_situation">
+            app:layout_constraintTop_toBottomOf="@id/draw_sv_select_type">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/home_category_cl1"
@@ -714,6 +532,7 @@
                 android:orientation="horizontal"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/home_category_cl3"
                 app:layout_constraintStart_toStartOf="parent">
 
                 <LinearLayout

--- a/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_tier_list.xml
+++ b/AndroidStudioProjects/Kustaurant/app/src/main/res/layout/fragment_tier_list.xml
@@ -53,6 +53,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="3dp"
                     android:text="@{viewModel.isExpanded ? @string/fab_reduce : @string/fab_expand}"
                     android:textColor="@color/black"
                     android:textSize="11sp"


### PR DESCRIPTION
## 개요
- 상황 버튼 관련 UI 및 로직 제거

- 원인 : 랜덤 뽑기 결과로 애니메이션이 실행되고 있는 동안 바텀 바를 통해 다른 프래그먼트로 이동하게 되면 runnable이 계속 실행되고 있어 오류가 발생하고 있음을 확인.
  해결 : handler, runnable을 변수로 선언해 onDestroyView()가 실행되면 관련 handler, runnable를 null처리하여 해결
<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
