### PR TITLE
[Fix] Refresh Token 만료 시 로그아웃 처리

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17">
-      <module name="Kustaurant.app" target="21" />
-    </bytecodeTargetLevel>
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="Kustaurant.app">
+      <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/com/kust/kustaurant/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/kust/kustaurant/data/network/TokenAuthenticator.kt
@@ -1,9 +1,11 @@
 package com.kust.kustaurant.data.network
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import com.kust.kustaurant.data.getAccessToken
 import com.kust.kustaurant.data.saveAccessToken
+import com.kust.kustaurant.presentation.ui.splash.StartActivity
 import okhttp3.Authenticator
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -24,6 +26,7 @@ class TokenAuthenticator(private val context: Context) : Authenticator {
                     .header("Authorization", "Bearer $newToken")
                     .build()
             } else {
+                handleLogout()
                 null
             }
         }
@@ -48,5 +51,17 @@ class TokenAuthenticator(private val context: Context) : Authenticator {
             Log.e("TokenAuthenticator", "Failed to refresh token: ${e.localizedMessage}")
         }
         return null
+    }
+
+    private fun handleLogout(){
+        context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE).edit().clear().apply()
+
+        val intent = Intent(context, StartActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+
+        context.startActivity(intent)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.0"
+agp = "8.7.0"
 flexbox = "3.0.0"
 kotlin = "1.9.23"
 coreKtx = "1.13.1"


### PR DESCRIPTION
## 개요
Refresh Token 만료 시 로그아웃이 안됨으로 인한 로그아웃, 음식점 상세 보기 등의 기능이 작동되지 않는 오류 해결
- Access Token을 새로 발급받을 때 response code가 401인데 새로운 Access Token 값이 넘어오지 않을 때 Refresh Token이 만료된 것으로 판단 -> 로그아웃 처리

<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
