### PR TITLE
[Fix] CommunityPostWriteActivity 이미지 접근 관련 정책 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,11 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Android 13(API 33) 이상에서 이미지를 읽기 위한 권한 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <!-- Android 12(API 32) 이하에서 이미지를 읽기 위한 권한 -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-
 
     <application
         android:name=".presentation.KustaurantApplication"

--- a/app/src/main/java/com/kust/kustaurant/presentation/ui/community/CommunityPostWriteActivity.kt
+++ b/app/src/main/java/com/kust/kustaurant/presentation/ui/community/CommunityPostWriteActivity.kt
@@ -1,12 +1,10 @@
 package com.kust.kustaurant.presentation.ui.community
 
 import android.annotation.SuppressLint
-import android.os.Bundle
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.net.Uri
-import android.os.Build
+import android.os.Bundle
 import android.provider.OpenableColumns
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -15,10 +13,10 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
@@ -26,7 +24,6 @@ import com.kust.kustaurant.R
 import com.kust.kustaurant.databinding.ActivityCommunityPostWriteBinding
 import com.kust.kustaurant.databinding.PopupCommuPostWriteSortBinding
 import com.kust.kustaurant.presentation.model.CommunityPostIntent
-import com.kust.kustaurant.presentation.ui.detail.EvaluateActivity.Companion.REQ_GALLERY
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -36,9 +33,9 @@ import kotlinx.coroutines.launch
 class CommunityPostWriteActivity : AppCompatActivity() {
     private lateinit var binding: ActivityCommunityPostWriteBinding
     private val viewModel: CommunityPostWriteViewModel by viewModels()
-    private lateinit var photoPickerLauncher: ActivityResultLauncher<Intent>
     private var textChangeJob: Job? = null
     private var postId : Int? = null
+    private lateinit var pickMedia: ActivityResultLauncher<PickVisualMediaRequest>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -164,20 +161,16 @@ class CommunityPostWriteActivity : AppCompatActivity() {
 
     // Fragment에서 ViewModel에서 반환된 HTML 값을 직접 설정하고 커서 위치 재확인
     private fun initPhotoPicker() {
-        photoPickerLauncher =
-            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-                if (result.resultCode == RESULT_OK) {
-                    result.data?.data?.let { uri ->
-                        lifecycleScope.launch {
-                            val imageUrl =
-                                viewModel.uploadImageAndGetUrl(uri, getFileNameFromUri(uri))
-                            imageUrl?.let {
-                                insertImageAtCursor(it)
-                            }
-                        }
+        pickMedia = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) {
+                lifecycleScope.launch {
+                    val imageUrl = viewModel.uploadImageAndGetUrl(uri, getFileNameFromUri(uri))
+                    imageUrl?.let {
+                        insertImageAtCursor(it)
                     }
                 }
             }
+        }
     }
 
     private fun insertImageAtCursor(imageUrl: String) {
@@ -186,43 +179,7 @@ class CommunityPostWriteActivity : AppCompatActivity() {
     }
 
     private fun selectGallery() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // Android 13 이상
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    android.Manifest.permission.READ_MEDIA_IMAGES
-                ) == PackageManager.PERMISSION_DENIED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(android.Manifest.permission.READ_MEDIA_IMAGES),
-                    REQ_GALLERY
-                )
-            } else {
-                openGallery()
-            }
-        } else {
-            // Android 12 이하
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    android.Manifest.permission.READ_EXTERNAL_STORAGE
-                ) == PackageManager.PERMISSION_DENIED
-            ) {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(android.Manifest.permission.READ_EXTERNAL_STORAGE),
-                    REQ_GALLERY
-                )
-            } else {
-                openGallery()
-            }
-        }
-    }
-
-    private fun openGallery() {
-        val intent = Intent(Intent.ACTION_PICK)
-        intent.type = "image/*"
-        photoPickerLauncher.launch(intent)
+        pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
     }
 
     private fun showPopupWindow() {
@@ -252,17 +209,6 @@ class CommunityPostWriteActivity : AppCompatActivity() {
     private fun updateSelectedPostSort(selectedText: String, popupWindow: PopupWindow) {
         viewModel.updatePostSort(selectedText)
         popupWindow.dismiss()
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQ_GALLERY && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            openGallery()
-        }
     }
 
     private fun getFileNameFromUri(uri: Uri): String {

--- a/app/src/main/res/layout/activity_community_post_detail.xml
+++ b/app/src/main/res/layout/activity_community_post_detail.xml
@@ -306,7 +306,7 @@
                             android:id="@+id/community_iv_btn_scrap_like"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:contentDescription="스크립 아이콘입니다."
+                            android:contentDescription="스크랩 아이콘입니다."
                             android:src="@drawable/ic_scrap" />
 
                         <TextView

--- a/app/src/main/res/layout/activity_community_post_detail.xml
+++ b/app/src/main/res/layout/activity_community_post_detail.xml
@@ -128,6 +128,7 @@
                         android:id="@+id/community_iv_user_icon"
                         android:layout_width="16dp"
                         android:layout_height="16dp"
+                        android:contentDescription="유저 아이콘 입니다."
                         android:src="@drawable/ic_baby_cow" />
 
                     <TextView
@@ -278,6 +279,7 @@
                             android:id="@+id/community_iv_btn_post_like"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:contentDescription="좋아요 아이콘 입니다."
                             android:src="@drawable/ic_like_true" />
 
                         <TextView
@@ -304,6 +306,7 @@
                             android:id="@+id/community_iv_btn_scrap_like"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:contentDescription="스크립 아이콘입니다."
                             android:src="@drawable/ic_scrap" />
 
                         <TextView
@@ -365,7 +368,7 @@
                 android:paddingHorizontal="16dp"
                 android:paddingVertical="14dp"
                 android:textColorHint="@color/cement_4"
-                android:textSize="14dp"
+                android:textSize="14sp"
                 app:layout_constraintEnd_toStartOf="@id/community_cl_comment_confirm"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -386,6 +389,8 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:contentDescription="댓글 입력 확인 버튼"
+                    android:paddingEnd="3dp"
+                    android:paddingStart="0dp"
                     android:src="@drawable/ic_confirm"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
커뮤니티에 이미지 업로드는 단발성 갤러리 접근이어서, 기존에 사용하던 퍼미션을 제거.
이미지 하나만 접근 할 수 있도록, ActivityResultLauncher<PickVisualMediaRequest> 변수를 사용.
<br/>

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
